### PR TITLE
updates name of /api/satellite route

### DIFF
--- a/controllers/api/index.js
+++ b/controllers/api/index.js
@@ -1,6 +1,6 @@
 const router = require('express').Router();
 const satelliteRoutes = require('./satelliteRoutes');
 
-router.use('/view', satelliteRoutes);
+router.use('/satellite', satelliteRoutes);
 
 module.exports = router;

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -22,7 +22,7 @@
             <h1>Satellite</h1>
             <nav>
                 <ul>
-                    <li><a href="/api/view">View Satellites</a></li>
+                    <li><a href="/api/satellite">View Satellites</a></li>
                     <li><a href="/">Home</a></li>
                     <li><a href="/about">About Us</a></li>
 


### PR DESCRIPTION
The name of the /api/view route was changed to use /api/satellite.  The corresponding link in the navigation menu was also updated to reflect the change.